### PR TITLE
Update key-management.mdx

### DIFF
--- a/docs/overview/key-management.mdx
+++ b/docs/overview/key-management.mdx
@@ -58,7 +58,7 @@ contract functionality.
 
 ### Censorship resistant
 
-Using a 2/3 threshold also prevents censorship by the Torus nodes. In the case that the nodes refuse to return the user's private key even after the
+Using a 2/3 threshold also prevents censorship by the Torus nodes. In the case that the nodes refuse to return the share of the user's private key even after the
 user has authenticated successfully, the user can still reconstruct their private key using ShareA (device share) and ShareC (recovery share).
 
 ## Powered by the Auth Network


### PR DESCRIPTION
https://docs.web3auth.io/overview/key-management
Censorship resistant
Using a 2/3 threshold also prevents censorship by the Torus nodes. In the case that the nodes refuse to return the user's private key even after the user has authenticated successfully, the user can still reconstruct their private key using ShareA (device share) and ShareC (recovery share).

Why do we say 
In the case that the nodes refuse to return the user's private key even after the user has authenticated successfully
Shouldn't it be a share of the private key