### PR TITLE
Fixed Plugin links in interoperability.mdx

### DIFF
--- a/docs/interoperability.mdx
+++ b/docs/interoperability.mdx
@@ -95,7 +95,7 @@ flows through the Torus Wallet.
 
 Currently, the following plugins are supported:
 
-- [Torus EVM Wallet UI Plugin](/api-reference/web/plugins/torussolanawalletplugin)
-- [Torus Solana Wallet UI Plugin](/api-reference/web/plugins/torusevmwalletplugin)
+- [Torus EVM Wallet UI Plugin](/api-reference/web/plugins/torusevmwalletplugin)
+- [Torus Solana Wallet UI Plugin](/api-reference/web/plugins/torussolanawalletplugin)
 
 Read more about them in the [Plugins API Reference](/api-reference/web/plugins).


### PR DESCRIPTION
_Torus EVM Wallet UI Plugin_ points to the link for the Solana Plugin.
Similarly, _Torus Solana Wallet UI Plugin_ points to the link for the EVM Plugin.

I have corrected this error in the commit.
