### PR TITLE
Fix grammatical error in overview/what-is-web3auth

### DIFF
--- a/docs/overview/what-is-web3auth.mdx
+++ b/docs/overview/what-is-web3auth.mdx
@@ -23,7 +23,7 @@ With Web3Auth integrated in your application, your user can sign up using the fl
   [here](./key-management.mdx).
 
 - **Holistic Web3 Wallet/Key Management Support**: Empower users to use their wallet or key management of choice. Using the Web3Auth suite, users can
-  use their existing wallet or key management of choice and hook it up with you application directly.
+  use their existing wallet or key management of choice and hook it up with your application directly.
 
 <ModalAnim />
 


### PR DESCRIPTION
Fixes grammatical typo in third paragraph on the page overview/what-is-web3auth