### PR TITLE
Update openlogin.mdx

### DIFF
--- a/docs/sdk/web/openlogin.mdx
+++ b/docs/sdk/web/openlogin.mdx
@@ -58,7 +58,7 @@ npm install --save @web3auth/openlogin-adapter
 
 ---
 
-#### Import the `OpenloginAdapter` class from `@web3auth/openlogin-adapter`
+#### Import the `{ OpenloginAdapter }` class from `@web3auth/openlogin-adapter`
 
 ```js
 import OpenloginAdapter from "@web3auth/openlogin-adapter";


### PR DESCRIPTION
Currently, importing `OpenlogInAdapter` is being imported as a default export. Which it isn't, therefore it should be imported as `{ OpenlogInAdapter }`