### PR TITLE
fix: mismatch description about status

### DIFF
--- a/src/common/sdk/web/_subscribe-events.mdx
+++ b/src/common/sdk/web/_subscribe-events.mdx
@@ -34,8 +34,8 @@ Web3Auth provides the following lifecycle event to check the login status:
 | `ADAPTER_DATA_UPDATED` | `ADAPTER_EVENTS.ADAPTER_DATA_UPDATED` | `"adapter_data_updated"` | Adapter data is updated within the dApp                      |
 | `NOT_READY`            | `ADAPTER_EVENTS.NOT_READY`            | `"not_ready"`            | Adapter is not yet ready for login                           |
 | `READY`                | `ADAPTER_EVENTS.READY`                | `"ready"`                | Adapter is ready for login                                   |
-| `CONNECTING`           | `ADAPTER_EVENTS.CONNECTING`           | `"connecting"`           | User is logged in and connected with the dApp                |
-| `CONNECTED`            | `ADAPTER_EVENTS.CONNECTED`            | `"connected"`            | User is connecting to the dApp/ login process is in progress |
+| `CONNECTING`           | `ADAPTER_EVENTS.CONNECTING`           | `"connecting"`           | User is connecting to the dApp/ login process is in progress |
+| `CONNECTED`            | `ADAPTER_EVENTS.CONNECTED`            | `"connected"`            | User is logged in and connected with the dApp                |
 | `DISCONNECTED`         | `ADAPTER_EVENTS.DISCONNECTED`         | `"disconnected"`         | User is logged out and disconnected from the dApp            |
 | `ERRORED`              | `ADAPTER_EVENTS.ERRORED`              | `"errored"`              | There has been some error in connecting the user to the dApp |
 


### PR DESCRIPTION
Probably the `connecting` and `connected` descriptions got swapped.
Revised it to what seems to be correct.