### PR TITLE
privacy-policy: Fix dashboard link

### DIFF
--- a/docs/legal/privacy-policy.mdx
+++ b/docs/legal/privacy-policy.mdx
@@ -7,7 +7,7 @@ Latest update: 2 June 2022
 
 
 
-This privacy policy is applicable to Web3Auth's Products (https://app.openlogin.com), Torus wallet (https://app.tor.us). This privacy policy explicitly excludes business and developer interactions including the website (https://dashboard.tor.us). The policy does extend to Web3Auth/Torus's interactions with clients that integrate its SDK, but does not include what data our clients manage and collect themselves.
+This privacy policy is applicable to Web3Auth's Products (https://app.openlogin.com), Torus wallet (https://app.tor.us). This privacy policy explicitly excludes business and developer interactions including the website (https://dashboard.web3auth.io). The policy does extend to Web3Auth/Torus's interactions with clients that integrate its SDK, but does not include what data our clients manage and collect themselves.
 
 ## Owner and Data Controller
 


### PR DESCRIPTION
Link pointed to https://dashboard.tor.us/, now pointing to https://dashboard.web3auth.io/.