### PR TITLE
docs/troubleshooting/sdk-errors-warnings.mdxUpdate sdk-errors-warnings.mdxsdk

### DIFF
--- a/docs/troubleshooting/sdk-errors-warnings.mdx
+++ b/docs/troubleshooting/sdk-errors-warnings.mdx
@@ -1,4 +1,4 @@
----
+---docs/troubleshooting/supported-browsers.mdx
 title: SDK Errors & Warnings
 image: "/docs/images/docs-meta-cards/troubleshoot-card.png"
 displayed_sidebar: docs


### PR DESCRIPTION
---
title: Supported Browsers List
image: "images/docs-meta-cards/troubleshoot-card.png"
displayed_sidebar: docs
description: "Supported Browsers List | Documentation - Web3Auth"
---

## Supported Browsers List

Web3Auth SDKs require BigInt support, which is not supported by all browsers. The list of browsers along with their versions that support BigInt are
listed below. The versions are listed according to this [page](https://browsersl.ist/#q=supports+bigint%2C+not+dead).

- Chrome 67+
- Chrome for Android 107+
- Safari 14+
- Safari on iOS 14+
- Edge 79+
- Firefox 68+
- Firefox for Android 106+
- Opera 54+
- Opera Mobile 72+
- Samsung Internet 9.2+
- UC Browser for Android 13.4+
- QQ Browser 13.1+
- Android Browser 107+

:::info source code

When creating your React App in production, make sure to follow the steps described [here](/troubleshooting/react-big-int-error) to avoid BigInt
Error.

:::