### PR TITLE
Wrong hex value for zKatana chainId

### DIFF
--- a/docs/connect-blockchain/zkatana.mdx
+++ b/docs/connect-blockchain/zkatana.mdx
@@ -78,7 +78,7 @@ const web3auth = new Web3Auth({
   web3AuthNetwork: "sapphire_mainnet",
   chainConfig: {
     chainNamespace: "eip155",
-    chainId: "0x133120", // hex of 1261120
+    chainId: "0x133E40", // hex of 1261120
     rpcTarget: "https://rpc.zkatana.gelato.digital",
     // Avoid using public rpcTarget in production.
     // Use services like Infura, Quicknode etc


### PR DESCRIPTION
The hex value fir the chainId is wrong
```1261120 = 0x133E40```