### PR TITLE
Add the connect snippet + updated aptos page

### DIFF
--- a/docs/connect-blockchain/evm/arbitrum/web.mdx
+++ b/docs/connect-blockchain/evm/arbitrum/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/astar-zkevm/web.mdx
+++ b/docs/connect-blockchain/evm/astar-zkevm/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -87,7 +88,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/astar-zkyoto/web.mdx
+++ b/docs/connect-blockchain/evm/astar-zkyoto/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -88,7 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/avalanche/web.mdx
+++ b/docs/connect-blockchain/evm/avalanche/web.mdx
@@ -33,6 +33,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -121,7 +122,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/base/web.mdx
+++ b/docs/connect-blockchain/evm/base/web.mdx
@@ -22,6 +22,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -110,7 +111,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/bnb/web.mdx
+++ b/docs/connect-blockchain/evm/bnb/web.mdx
@@ -32,6 +32,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -120,7 +121,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/celo/web.mdx
+++ b/docs/connect-blockchain/evm/celo/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -108,7 +109,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/cronos/web.mdx
+++ b/docs/connect-blockchain/evm/cronos/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/ethereum/web.mdx
+++ b/docs/connect-blockchain/evm/ethereum/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/fhenix/web.mdx
+++ b/docs/connect-blockchain/evm/fhenix/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -88,7 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/flare/web.mdx
+++ b/docs/connect-blockchain/evm/flare/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -111,7 +112,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/harmony/web.mdx
+++ b/docs/connect-blockchain/evm/harmony/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/hedera/web.mdx
+++ b/docs/connect-blockchain/evm/hedera/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -126,7 +127,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/kinto/web.mdx
+++ b/docs/connect-blockchain/evm/kinto/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -105,7 +106,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/klaytn/web.mdx
+++ b/docs/connect-blockchain/evm/klaytn/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/linea/web.mdx
+++ b/docs/connect-blockchain/evm/linea/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -106,7 +107,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/manta/web.mdx
+++ b/docs/connect-blockchain/evm/manta/web.mdx
@@ -31,6 +31,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -111,11 +112,13 @@ const chainConfig = {
 </TabItem>
 </Tabs>
 
-### Initializing and Instantiating the Web3Auth SDK
+### Initializing and instantiating the Web3Auth SDK
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/moonbeam/web.mdx
+++ b/docs/connect-blockchain/evm/moonbeam/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/moonriver/web.mdx
+++ b/docs/connect-blockchain/evm/moonriver/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/morph/web.mdx
+++ b/docs/connect-blockchain/evm/morph/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -105,7 +106,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/neon/web.mdx
+++ b/docs/connect-blockchain/evm/neon/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/nibiru/web.mdx
+++ b/docs/connect-blockchain/evm/nibiru/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -100,7 +101,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/opbnb/web.mdx
+++ b/docs/connect-blockchain/evm/opbnb/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -111,7 +112,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/optimism/web.mdx
+++ b/docs/connect-blockchain/evm/optimism/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -109,7 +110,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/polygon/web.mdx
+++ b/docs/connect-blockchain/evm/polygon/web.mdx
@@ -32,6 +32,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -120,7 +121,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/rootstock/web.mdx
+++ b/docs/connect-blockchain/evm/rootstock/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -106,7 +107,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/saakuru/web.mdx
+++ b/docs/connect-blockchain/evm/saakuru/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -73,7 +74,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/shardeum/web.mdx
+++ b/docs/connect-blockchain/evm/shardeum/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -88,7 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/skale/web.mdx
+++ b/docs/connect-blockchain/evm/skale/web.mdx
@@ -20,6 +20,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -263,7 +264,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/soneium/web.mdx
+++ b/docs/connect-blockchain/evm/soneium/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -114,7 +115,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/songbird/web.mdx
+++ b/docs/connect-blockchain/evm/songbird/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -110,7 +111,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/xpla/web.mdx
+++ b/docs/connect-blockchain/evm/xpla/web.mdx
@@ -19,6 +19,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -83,7 +84,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/zetachain/web.mdx
+++ b/docs/connect-blockchain/evm/zetachain/web.mdx
@@ -21,6 +21,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -87,7 +88,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/evm/zilliqa/web.mdx
+++ b/docs/connect-blockchain/evm/zilliqa/web.mdx
@@ -32,6 +32,7 @@ import DeployContractSolidityReadSnippet from "@site/src/common/docs/_smart-cont
 import DeployContractSolidityWriteSnippet from "@site/src/common/docs/_smart-contract-solidity-write.mdx";
 import FetchUserPrivateKeySnippet from "@site/src/common/docs/web-connect-blockchain/_evm-fetch-user-private-key.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-evm-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import SEO from "@site/src/components/SEO";
@@ -92,11 +93,13 @@ const chainConfig = {
 </TabItem>
 </Tabs>
 
-### Initializing and Instantiating the Web3Auth SDK
+### Initializing and instantiating the Web3Auth SDK
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/near/web.mdx
+++ b/docs/connect-blockchain/near/web.mdx
@@ -8,6 +8,7 @@ description: "Integrate Web3Auth with the Near Protocol | Documentation - Web3Au
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -77,7 +78,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/algorand.mdx
+++ b/docs/connect-blockchain/other/algorand.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Algorand Blockchain | Documentation - 
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
@@ -90,7 +91,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/aptos.mdx
+++ b/docs/connect-blockchain/other/aptos.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Aptos Blockchain | Documentation - Web
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -88,9 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
 
-<GetUserInfoSnippet />
+<GetWeb3AuthProvider />
 
 ## Get Account and Key
 
@@ -108,10 +109,9 @@ On the underhood, it uses the helper functions from the `aptos` library to deriv
 import { AptosAccount, AptosClient } from "aptos";
 
 /*
-  Use code from the above Initializing Provider here
+  Use code from the above InitializeWeb3Auth and get provider steps
 */
 
-// web3authProvider is web3auth.provider from above
 const privateKey = await web3authProvider.request({ method: "private_key" });
 const privateKeyUint8Array = new Uint8Array(
   privateKey.match(/.{1,2}/g)!.map((byte: any) => parseInt(byte, 16)),
@@ -126,10 +126,9 @@ const aptosAccountAddress = aptosAccount.address();
 import { AptosAccount, AptosClient } from "aptos";
 
 /*
-  Use code from the above Initializing Provider here
+  Use code from the above InitializeWeb3Auth and get provider steps
 */
 
-// web3authProvider is web3auth.provider from above
 const privateKey = await web3authProvider.request({ method: "private_key" });
 const privateKeyUint8Array = new Uint8Array(
   privateKey.match(/.{1,2}/g)!.map((byte: any) => parseInt(byte, 16)),
@@ -153,10 +152,9 @@ let balance = parseInt((accountResource?.data as any).coin.value);
 import { AptosAccount, FaucetClient, AptosClient } from "aptos";
 
 /*
-  Use code from the above Initializing Provider here
+  Use code from the above InitializeWeb3Auth and get provider steps
 */
 
-// web3authProvider is web3auth.provider from above
 const privateKey = await web3authProvider.request({ method: "private_key" });
 const privateKeyUint8Array = new Uint8Array(
   privateKey.match(/.{1,2}/g)!.map((byte: any) => parseInt(byte, 16)),

--- a/docs/connect-blockchain/other/bitcoin.mdx
+++ b/docs/connect-blockchain/other/bitcoin.mdx
@@ -22,6 +22,7 @@ description: "Integrate Web3Auth with the Bitcoin Blockchain | Documentation - W
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
 
 When using the Web3Auth Web SDK for non-EVM chains like [Bitcoin](https://developer.bitcoin.org/),
@@ -94,7 +95,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/cosmos.mdx
+++ b/docs/connect-blockchain/other/cosmos.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Cosmos Blockchain | Documentation - We
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -87,7 +88,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/immutablex.mdx
+++ b/docs/connect-blockchain/other/immutablex.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the ImmutableX Blockchain | Documentation 
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -90,7 +91,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/polkadot.mdx
+++ b/docs/connect-blockchain/other/polkadot.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Polkadot Blockchain | Documentation - 
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -81,7 +82,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/polymesh.mdx
+++ b/docs/connect-blockchain/other/polymesh.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Polymesh Blockchain | Documentation - 
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -83,7 +84,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/starkex.mdx
+++ b/docs/connect-blockchain/other/starkex.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the StarkEx Blockchain | Documentation - W
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -88,7 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/starknet.mdx
+++ b/docs/connect-blockchain/other/starknet.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the StarkNet Blockchain | Documentation - 
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -88,7 +89,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/sui.mdx
+++ b/docs/connect-blockchain/other/sui.mdx
@@ -9,6 +9,7 @@ description: "Integrate Web3Auth with the Sui Blockchain | Documentation - Web3A
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 
@@ -80,7 +81,9 @@ const chainConfig = {
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/docs/connect-blockchain/other/ton.mdx
+++ b/docs/connect-blockchain/other/ton.mdx
@@ -8,6 +8,7 @@ description: "Integrate Web3Auth with the TON Blockchain | Documentation - Web3A
 
 import GetUserInfoSnippet from "@site/src/common/docs/_get-userinfo.mdx";
 import InitializeWeb3Auth from "@site/src/common/docs/_initialize-web3auth-other-pnp-sfa.mdx";
+import GetWeb3AuthProvider from "@site/src/common/docs/_get-web3auth-provider.mdx";
 
 While using the Web3Auth Web SDK for a non-EVM chain like [TON](https://ton.org/), you get a
 standard provider from which you can obtain the private key of the user. Using this private key, you
@@ -43,7 +44,9 @@ const rpc = await getHttpEndpoint();
 
 <InitializeWeb3Auth />
 
-## Get User Info
+## Getting the Web3Auth provider
+
+<GetWeb3AuthProvider />
 
 <GetUserInfoSnippet />
 

--- a/src/common/docs/_get-web3auth-provider.mdx
+++ b/src/common/docs/_get-web3auth-provider.mdx
@@ -1,0 +1,69 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+After initializing Web3Auth, the next step is to initialize the provider and use it for your
+operations.
+
+<Tabs
+  defaultValue="modal"
+  values={[
+    { label: "PnP Modal SDK", value: "modal", },
+    { label: "PnP NoModal SDK", value: "no-modal", },
+    { label: "CoreKit SFA Web SDK", value: "sfa", },
+  ]}
+>
+<TabItem
+  value="modal"
+>
+
+```tsx
+// Initialize for PnP Modal SDK
+await web3auth.initModal();
+
+// Trigger the login
+await web3auth.connect();
+
+// Get the provider
+const provider = web3auth.provider;
+
+// Continue using the `provider`
+```
+
+</TabItem>
+<TabItem
+  value="no-modal"
+>
+
+```tsx
+// Initialize for PnP NoModal SDK
+await web3auth.init();
+
+// Trigger the login
+await web3auth.connectTo("openlogin");
+
+// Get the provider
+const provider = web3auth.provider;
+
+// Continue using the `provider`
+```
+
+</TabItem>
+<TabItem
+  value="sfa"
+>
+
+```tsx
+// Initialize for CoreKit SFA Web SDK
+await web3auth.init();
+
+// Trigger the login
+await web3auth.connect();
+
+// Get the provider
+const provider = web3auth.provider;
+
+// Continue using the `provider`
+```
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://toruslabs.atlassian.net/browse/DEVREL-957?atlOrigin=eyJpIjoiYjc0NDNkYWYyMThiNDExNzk3YzI0MGE4YTQ1MTdhZDUiLCJwIjoiaiJ9

**Why is this change required?**
The change is required to address frequent feedback we received regarding missing steps between the initialization of Web3Auth and the start of RPC functions in the "Connect Blockchain" documentation pages. This issue was causing confusion for users integrating various blockchains (including Aptos) as they were unable to retrieve the Web3Auth provider properly after logging in.

**Problem it solves:**
This update fills in the missing steps to retrieve the Web3Auth provider, ensuring proper functionality across multiple blockchains. It allows users to proceed seamlessly with accessing blockchain features, such as fetching balances and executing transactions.

## Description
<!--- Describe your changes in detail -->

- **Added an updated Aptos "Connect Blockchain" page** in the Web3Auth documentation, which aligns with the new example provided in the Aptos repository. The example is part of [this pull request](https://github.com/Web3Auth/web3auth-pnp-examples/pull/1248), and the documentation update ensures consistency with that example.
- **Created a modular snippet** for getting the Web3Auth provider after initialization, which includes the `init`, `initModal`, and login/connect steps. This ensures that users can successfully retrieve the provider for subsequent RPC operations.
- **Applied the modular snippet to all "Connect Blockchain" pages** across the documentation, as the missing steps not only affected Aptos but all blockchains listed under "Connect Blockchain."
- Ensured that the documentation is now clear and concise, providing all necessary steps for users to access their Web3Auth provider and interact with their respective blockchains.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- **Locally tested** the updated Aptos integration using the new example to ensure that the Web3Auth provider is correctly retrieved after login and that subsequent interactions (e.g., fetching balances, sending transactions) work as expected.
- Verified that the modular snippet works across **other blockchain integrations** and that the missing steps no longer cause issues in the documentation for any other blockchain.
- Ensured the Aptos integration and other blockchain pages follow the same flow and structure.

## Screenshots (if appropriate):
![ezgif-7-72ffa1f3f8](https://github.com/user-attachments/assets/e642174d-e7ea-44a8-a5ba-e046b38fcc44)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (ran `lint`)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
