### PR TITLE
Lock to web3.js 1.x for compatibility

### DIFF
--- a/src/common/sdk/core-kit/mpc-core-kit/_solana-installation.mdx
+++ b/src/common/sdk/core-kit/mpc-core-kit/_solana-installation.mdx
@@ -1,4 +1,4 @@
 ```bash npm2yarn
-$ npm install @solana/web3.js
+$ npm install @solana/web3.js@1
 $ npm install @toruslabs/tss-frost-lib
 ```


### PR DESCRIPTION
Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498